### PR TITLE
fix: compatible release version specifier missed

### DIFF
--- a/01- Docker/README.md
+++ b/01- Docker/README.md
@@ -145,7 +145,7 @@ $ mkdir code && cd code
 
 ```shell
 $ mkdir hello && cd hello
-$ pipenv install django=3.1.0
+$ pipenv install django~=3.1.0
 $ pipenv shell
 (hello) $
 ```


### PR DESCRIPTION
in the book, this section is using a compatible release version specifier which is missing in the translated `md` (and perhaps pdf) file. 